### PR TITLE
Require underscore.string explicitly (required for latest yo version)

### DIFF
--- a/class/component.js
+++ b/class/component.js
@@ -3,6 +3,7 @@
 
 var path = require('path');
 var _ = require('lodash');
+var _str = require('underscore.string');
 var utils = require('../utils');
 var Class = require('./index.js');
 var _localFolder;
@@ -85,7 +86,7 @@ var ComponentGenerator = Class.extend({
             message: 'What is the name of your module ?',
             default: that.modulename || (choices && choices.length >= 1 ? choices[0].value : that.modulename),
             validate: function(value) {
-                value = _.str.trim(value);
+                value = _str.trim(value);
                 if (_.isEmpty(value) || value[0] === '/' || value[0] === '\\') {
                     return 'Please enter a non empty name';
                 }
@@ -102,7 +103,7 @@ var ComponentGenerator = Class.extend({
             message: 'How would like to name your ' + _templateFolder + ' ?',
             validate: function(value) {
 
-                value = _.str.trim(value);
+                value = _str.trim(value);
                 if (_.isEmpty(value) || value[0] === '/' || value[0] === '\\') {
                     that.prompt_errors = 'Please enter a non empty name';
                     return 'Please enter a non empty name';

--- a/class/component.js
+++ b/class/component.js
@@ -3,7 +3,6 @@
 
 var path = require('path');
 var _ = require('lodash');
-var _str = require('underscore.string');
 var utils = require('../utils');
 var Class = require('./index.js');
 var _localFolder;
@@ -86,7 +85,7 @@ var ComponentGenerator = Class.extend({
             message: 'What is the name of your module ?',
             default: that.modulename || (choices && choices.length >= 1 ? choices[0].value : that.modulename),
             validate: function(value) {
-                value = _str.trim(value);
+                value = _.trim(value);
                 if (_.isEmpty(value) || value[0] === '/' || value[0] === '\\') {
                     return 'Please enter a non empty name';
                 }
@@ -103,7 +102,7 @@ var ComponentGenerator = Class.extend({
             message: 'How would like to name your ' + _templateFolder + ' ?',
             validate: function(value) {
 
-                value = _str.trim(value);
+                value = _.trim(value);
                 if (_.isEmpty(value) || value[0] === '/' || value[0] === '\\') {
                     that.prompt_errors = 'Please enter a non empty name';
                     return 'Please enter a non empty name';

--- a/module/index.js
+++ b/module/index.js
@@ -2,6 +2,7 @@
 
 var path = require('path');
 var _ = require('lodash');
+var _str = require('underscore.string');
 var Class = require('../class');
 var utils = require('../utils.js');
 
@@ -68,7 +69,7 @@ var ModuleGenerator = Class.extend({
             message: 'What is the name of your module ?',
             default: this.modulename,
             validate: function(value) {
-                value = _.str.trim(value);
+                value = _str.trim(value);
                 if (_.isEmpty(value) || value[0] === '/' || value[0] === '\\') {
                     return 'Please enter a non empty name';
                 }

--- a/module/index.js
+++ b/module/index.js
@@ -2,7 +2,6 @@
 
 var path = require('path');
 var _ = require('lodash');
-var _str = require('underscore.string');
 var Class = require('../class');
 var utils = require('../utils.js');
 
@@ -69,7 +68,7 @@ var ModuleGenerator = Class.extend({
             message: 'What is the name of your module ?',
             default: this.modulename,
             validate: function(value) {
-                value = _str.trim(value);
+                value = _.trim(value);
                 if (_.isEmpty(value) || value[0] === '/' || value[0] === '\\') {
                     return 'Please enter a non empty name';
                 }

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "stream-combiner": "0.2.2",
     "strip-json-comments": "1.0.4",
     "try-thread-sleep": "1.0.0",
-    "underscore.string": "~3.3.4",
     "yargs": "3.30.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "stream-combiner": "0.2.2",
     "strip-json-comments": "1.0.4",
     "try-thread-sleep": "1.0.0",
+    "underscore.string": "~3.3.4",
     "yargs": "3.30.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "yosay": "1.1.0"
   },
   "devDependencies": {
-    "babel-eslint": "4.1.5",
+    "babel-eslint": "4.1.8",
     "chai": "3.4.1",
     "codeclimate-test-reporter": "0.1.1",
     "conventional-changelog": "0.5.1",

--- a/service/index.js
+++ b/service/index.js
@@ -2,6 +2,7 @@
 
 var path = require('path');
 var _ = require('lodash');
+var _str = require('underscore.string');
 var utils = require('../utils');
 var Class = require('../class');
 
@@ -101,7 +102,7 @@ var ServiceGenerator = Class.extend({
             message: 'What is the name of your module ?',
             default: that.modulename || (choices && choices.length >= 1 ? choices[0].value : that.modulename),
             validate: function(value) {
-                value = _.str.trim(value);
+                value = _str.trim(value);
                 if (_.isEmpty(value) || value[0] === '/' || value[0] === '\\') {
                     return 'Please enter a non empty name';
                 }
@@ -117,7 +118,7 @@ var ServiceGenerator = Class.extend({
             },
             message: 'How would like to name your service ?',
             validate: function(value) {
-                value = _.str.trim(value);
+                value = _str.trim(value);
                 if (_.isEmpty(value) || value[0] === '/' || value[0] === '\\') {
                     return 'Please enter a non empty name';
                 }

--- a/service/index.js
+++ b/service/index.js
@@ -2,7 +2,6 @@
 
 var path = require('path');
 var _ = require('lodash');
-var _str = require('underscore.string');
 var utils = require('../utils');
 var Class = require('../class');
 
@@ -102,7 +101,7 @@ var ServiceGenerator = Class.extend({
             message: 'What is the name of your module ?',
             default: that.modulename || (choices && choices.length >= 1 ? choices[0].value : that.modulename),
             validate: function(value) {
-                value = _str.trim(value);
+                value = _.trim(value);
                 if (_.isEmpty(value) || value[0] === '/' || value[0] === '\\') {
                     return 'Please enter a non empty name';
                 }
@@ -118,7 +117,7 @@ var ServiceGenerator = Class.extend({
             },
             message: 'How would like to name your service ?',
             validate: function(value) {
-                value = _str.trim(value);
+                value = _.trim(value);
                 if (_.isEmpty(value) || value[0] === '/' || value[0] === '\\') {
                     return 'Please enter a non empty name';
                 }

--- a/target/index.js
+++ b/target/index.js
@@ -2,7 +2,6 @@
 
 var path = require('path');
 var _ = require('lodash');
-var _str = require('underscore.string');
 var Class = require('../class');
 
 var TargetGenerator = Class.extend({
@@ -64,7 +63,7 @@ var TargetGenerator = Class.extend({
             message: 'What is the name of your target application?',
             default: this.targetname,
             validate: function(value) {
-                value = _str.trim(value);
+                value = _.trim(value);
                 if (_.isEmpty(value) || value[0] === '/' || value[0] === '\\') {
                     return 'Please enter a non empty name';
                 }

--- a/target/index.js
+++ b/target/index.js
@@ -2,6 +2,7 @@
 
 var path = require('path');
 var _ = require('lodash');
+var _str = require('underscore.string');
 var Class = require('../class');
 
 var TargetGenerator = Class.extend({
@@ -63,7 +64,7 @@ var TargetGenerator = Class.extend({
             message: 'What is the name of your target application?',
             default: this.targetname,
             validate: function(value) {
-                value = _.str.trim(value);
+                value = _str.trim(value);
                 if (_.isEmpty(value) || value[0] === '/' || value[0] === '\\') {
                     return 'Please enter a non empty name';
                 }


### PR DESCRIPTION
With your latest generator version and an up to date yeoman (1.7.0) the subgenerators fail because _str is undefined.

I have therefore required underscore.string explicitly.